### PR TITLE
feat: 이미지 업로드를 위한 S3 연동 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,10 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+	//s3
+	implementation 'software.amazon.awssdk:s3:2.20.26'
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
 	// Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 

--- a/src/main/java/com/example/myNutrition/common/config/WebConfig.java
+++ b/src/main/java/com/example/myNutrition/common/config/WebConfig.java
@@ -1,0 +1,23 @@
+package com.example.myNutrition.common.config;
+
+import com.example.myNutrition.common.util.MultipartJackson2HttpMessageConverter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private final MultipartJackson2HttpMessageConverter multipartJackson2HttpMessageConverter;
+
+    public WebConfig(MultipartJackson2HttpMessageConverter multipartJackson2HttpMessageConverter) {
+        this.multipartJackson2HttpMessageConverter = multipartJackson2HttpMessageConverter;
+    }
+
+    @Override
+    public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
+        // 컨버터 리스트에 사용자 정의 컨버터 추가
+        converters.add(multipartJackson2HttpMessageConverter);
+    }
+}

--- a/src/main/java/com/example/myNutrition/common/util/MultipartJackson2HttpMessageConverter.java
+++ b/src/main/java/com/example/myNutrition/common/util/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,35 @@
+package com.example.myNutrition.common.util;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Type;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+    /**
+     * "Content-Type: multipart/form-data" 헤더를 지원하는 HTTP 요청 변환기
+     */
+    public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/src/main/java/com/example/myNutrition/domain/meal/controller/MealController.java
+++ b/src/main/java/com/example/myNutrition/domain/meal/controller/MealController.java
@@ -55,8 +55,7 @@ public class MealController {
             @RequestPart("image") MultipartFile imageFile
     ) {
         String imageUrl = s3Service.uploadImage(imageFile);
-        request.setImageUrl(imageUrl); // setter 또는 빌더 패턴 필요
-        Long mealRecordId = mealRecordService.registerMealRecord(request);
+        Long mealRecordId = mealRecordService.registerMealRecord(request, imageUrl);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new SingleResponse<>(201, "음식 기록 등록 완료", mealRecordId));
     }

--- a/src/main/java/com/example/myNutrition/domain/meal/dto/request/MealFoodRegisterRequestDto.java
+++ b/src/main/java/com/example/myNutrition/domain/meal/dto/request/MealFoodRegisterRequestDto.java
@@ -12,7 +12,7 @@ import java.util.List;
 @AllArgsConstructor
 public class MealFoodRegisterRequestDto {
     private MealType mealType;
-    private String imageUrl;
+    //private String imageUrl;
     private List<MealFoodDto> foods;
 
     @Getter
@@ -45,8 +45,5 @@ public class MealFoodRegisterRequestDto {
             private Double vitaminE;             // 비타민E(mg α-TE)
             private Double vitaminB6;            // 비타민B6(mg)
         }
-    }
-    public void setImageUrl(String imageUrl) {
-        this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/com/example/myNutrition/domain/meal/dto/request/MealFoodRegisterRequestDto.java
+++ b/src/main/java/com/example/myNutrition/domain/meal/dto/request/MealFoodRegisterRequestDto.java
@@ -46,4 +46,7 @@ public class MealFoodRegisterRequestDto {
             private Double vitaminB6;            // 비타민B6(mg)
         }
     }
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/com/example/myNutrition/domain/meal/service/MealRecordService.java
+++ b/src/main/java/com/example/myNutrition/domain/meal/service/MealRecordService.java
@@ -29,7 +29,7 @@ public class MealRecordService {
     private final MealRecordRepository mealRecordRepository;
 
     @Transactional
-    public Long registerMealRecord(MealFoodRegisterRequestDto request) {
+    public Long registerMealRecord(MealFoodRegisterRequestDto request, String imageUrl) {
         Long userId = SecurityUtils.getCurrentUserId();
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
@@ -42,7 +42,7 @@ public class MealRecordService {
 
         // MealImage 생성
         MealImage image = MealImage.builder()
-                .imageUrl(request.getImageUrl())
+                .imageUrl(imageUrl)
                 .mealRecord(mealRecord)
                 .build();
 

--- a/src/main/java/com/example/myNutrition/infra/s3/S3Config.java
+++ b/src/main/java/com/example/myNutrition/infra/s3/S3Config.java
@@ -1,0 +1,32 @@
+package com.example.myNutrition.infra.s3;
+
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCredentials= new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/example/myNutrition/infra/s3/S3Service.java
+++ b/src/main/java/com/example/myNutrition/infra/s3/S3Service.java
@@ -1,0 +1,51 @@
+package com.example.myNutrition.infra.s3;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.example.myNutrition.infra.s3.exception.ImageTypeException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String uploadImage(MultipartFile multipartFile) {
+        validateImageExtension(multipartFile);
+
+        String fileName = createUniqueFileName(multipartFile.getOriginalFilename());
+        try {
+            amazonS3Client.putObject(bucket, fileName, multipartFile.getInputStream(), null);
+        } catch (IOException e) {
+            throw new RuntimeException("S3 파일 업로드 실패", e);
+        }
+
+        return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+
+    private void validateImageExtension(MultipartFile file) {
+        List<String> validExtensions = List.of("jpg", "jpeg", "png", "gif");
+        String ext = getExtension(file.getOriginalFilename());
+        if (!validExtensions.contains(ext.toLowerCase())) {
+            throw new ImageTypeException("jpg/jpeg/png/gif만 업로드 가능합니다.");
+        }
+    }
+
+    private String createUniqueFileName(String originalName) {
+        return UUID.randomUUID() + "." + getExtension(originalName);
+    }
+
+    private String getExtension(String fileName) {
+        return fileName.substring(fileName.lastIndexOf('.') + 1);
+    }
+}

--- a/src/main/java/com/example/myNutrition/infra/s3/exception/ImageTypeException.java
+++ b/src/main/java/com/example/myNutrition/infra/s3/exception/ImageTypeException.java
@@ -1,0 +1,7 @@
+package com.example.myNutrition.infra.s3.exception;
+
+public class ImageTypeException extends RuntimeException {
+    public ImageTypeException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
### 작업 내용
- S3Config 및 S3Service 클래스 구현
- `application-aws.yml` 환경설정 추가
- 이미지 업로드 시 S3에 저장되도록 `uploadImage()` 메서드 구현
- 업로드 파일명 중복 방지를 위한 UUID 기반 파일명 생성
- 확장자 및 파일 크기 유효성 검사 로직 추가
- 업로드된 이미지의 S3 URL 반환

### 추가사항
- S3 버킷 정책 설정 필요 (`GetObject` 권한 부여)
- 최대 파일 크기: 5MB
- 지원 확장자: jpg, jpeg, png, gif
