### PR TITLE
feat: 음식 기록 및 하루 섭취 영양소 기능 구현 + S3 이미지 업로드 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,10 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+	//s3
+	implementation 'software.amazon.awssdk:s3:2.20.26'
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
 	// Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 

--- a/src/main/java/com/example/myNutrition/common/config/WebConfig.java
+++ b/src/main/java/com/example/myNutrition/common/config/WebConfig.java
@@ -1,0 +1,23 @@
+package com.example.myNutrition.common.config;
+
+import com.example.myNutrition.common.util.MultipartJackson2HttpMessageConverter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private final MultipartJackson2HttpMessageConverter multipartJackson2HttpMessageConverter;
+
+    public WebConfig(MultipartJackson2HttpMessageConverter multipartJackson2HttpMessageConverter) {
+        this.multipartJackson2HttpMessageConverter = multipartJackson2HttpMessageConverter;
+    }
+
+    @Override
+    public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
+        // 컨버터 리스트에 사용자 정의 컨버터 추가
+        converters.add(multipartJackson2HttpMessageConverter);
+    }
+}

--- a/src/main/java/com/example/myNutrition/common/util/MultipartJackson2HttpMessageConverter.java
+++ b/src/main/java/com/example/myNutrition/common/util/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,35 @@
+package com.example.myNutrition.common.util;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Type;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+    /**
+     * "Content-Type: multipart/form-data" 헤더를 지원하는 HTTP 요청 변환기
+     */
+    public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/src/main/java/com/example/myNutrition/domain/meal/controller/MealController.java
+++ b/src/main/java/com/example/myNutrition/domain/meal/controller/MealController.java
@@ -4,7 +4,7 @@ import com.example.myNutrition.common.response.SingleResponse;
 import com.example.myNutrition.domain.meal.dto.request.MealFoodRegisterRequestDto;
 import com.example.myNutrition.domain.meal.dto.response.DailyMealRecordResponseDto;
 import com.example.myNutrition.domain.meal.dto.response.DailyNutritionSummaryResponseDto;
-import com.example.myNutrition.domain.meal.entity.MealTime;
+import com.example.myNutrition.domain.meal.entity.MealType;
 import com.example.myNutrition.domain.meal.service.MealRecordService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -71,10 +71,10 @@ public class MealController {
             @Parameter(description = "조회할 날짜", example = "2025-04-04")
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
             @Parameter(description = "식사 시간 (BREAKFAST, LUNCH, DINNER, SNACK)", example = "LUNCH")
-            @PathVariable MealTime mealTime
+            @PathVariable MealType mealType
     ) {
-        DailyMealRecordResponseDto.MealRecordDto result = mealRecordService.getMealRecordByTime(date, mealTime);
-        return ResponseEntity.ok(new SingleResponse<>(200, mealTime.getDisplayName() + " 식사 조회 완료", result));
+        DailyMealRecordResponseDto.MealRecordDto result = mealRecordService.getMealRecordByTime(date, mealType);
+        return ResponseEntity.ok(new SingleResponse<>(200, mealType.getDisplayName() + " 식사 조회 완료", result));
     }
 
     @Operation(summary = "하루 영양소 총합 조회", description = "사용자가 하루 동안 섭취한 총 영양소 정보를 조회합니다.")

--- a/src/main/java/com/example/myNutrition/domain/meal/controller/MealController.java
+++ b/src/main/java/com/example/myNutrition/domain/meal/controller/MealController.java
@@ -55,8 +55,7 @@ public class MealController {
             @RequestPart("image") MultipartFile imageFile
     ) {
         String imageUrl = s3Service.uploadImage(imageFile);
-        request.setImageUrl(imageUrl); // setter 또는 빌더 패턴 필요
-        Long mealRecordId = mealRecordService.registerMealRecord(request);
+        Long mealRecordId = mealRecordService.registerMealRecord(request, imageUrl);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new SingleResponse<>(201, "음식 기록 등록 완료", mealRecordId));
     }

--- a/src/main/java/com/example/myNutrition/domain/meal/dto/request/MealFoodRegisterRequestDto.java
+++ b/src/main/java/com/example/myNutrition/domain/meal/dto/request/MealFoodRegisterRequestDto.java
@@ -20,6 +20,7 @@ public class MealFoodRegisterRequestDto {
     @AllArgsConstructor
     public static class MealFoodDto {
         private String name;
+        private String fullName;
         private double eatAmount;
         private NutritionDetailDto nutrition;
 

--- a/src/main/java/com/example/myNutrition/domain/meal/dto/request/MealFoodRegisterRequestDto.java
+++ b/src/main/java/com/example/myNutrition/domain/meal/dto/request/MealFoodRegisterRequestDto.java
@@ -12,7 +12,7 @@ import java.util.List;
 @AllArgsConstructor
 public class MealFoodRegisterRequestDto {
     private MealType mealType;
-    private String imageUrl;
+    //private String imageUrl;
     private List<MealFoodDto> foods;
 
     @Getter
@@ -45,8 +45,5 @@ public class MealFoodRegisterRequestDto {
             private Double vitaminE;             // 비타민E(mg α-TE)
             private Double vitaminB6;            // 비타민B6(mg)
         }
-    }
-    public void setImageUrl(String imageUrl) {
-        this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/com/example/myNutrition/domain/meal/dto/request/MealFoodRegisterRequestDto.java
+++ b/src/main/java/com/example/myNutrition/domain/meal/dto/request/MealFoodRegisterRequestDto.java
@@ -1,6 +1,6 @@
 package com.example.myNutrition.domain.meal.dto.request;
 
-import com.example.myNutrition.domain.meal.entity.MealTime;
+import com.example.myNutrition.domain.meal.entity.MealType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,7 +11,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MealFoodRegisterRequestDto {
-    private MealTime mealTime;
+    private MealType mealTime;
     private String imageUrl;
     private List<MealFoodDto> foods;
 
@@ -27,14 +27,22 @@ public class MealFoodRegisterRequestDto {
         @NoArgsConstructor
         @AllArgsConstructor
         public static class NutritionDetailDto {
-            private Double energy;
-            private Double carbohydrate;
-            private Double protein;
-            private Double fat;
-            private Double vitaminA;
-            private Double vitaminC;
-            private Double calcium;
-            // 필요한 영양소 계속 추가 가능
+            private Double energy;               // 에너지(kcal)
+            private Double carbohydrate;         // 탄수화물(g)
+            private Double protein;              // 단백질(g)
+            private Double fat;                  // 지방(g)
+            private Double saturatedFattyAcid;   // 포화지방산(g)
+            private Double transFattyAcid;       // 트랜스지방산(g)
+            private Double cholesterol;          // 콜레스테롤(mg)
+            private Double totalSugars;          // 당류(g)
+            private Double totalDietaryFiber;    // 식이섬유(g)
+            private Double sodium;               // 나트륨(mg)
+            private Double calcium;              // 칼슘(mg)
+            private Double vitaminA;             // 비타민A(μg RE)
+            private Double vitaminC;             // 비타민C(mg)
+            private Double vitaminD;             // 비타민D(μg)
+            private Double vitaminE;             // 비타민E(mg α-TE)
+            private Double vitaminB6;            // 비타민B6(mg)
         }
     }
 }

--- a/src/main/java/com/example/myNutrition/domain/meal/dto/request/MealFoodRegisterRequestDto.java
+++ b/src/main/java/com/example/myNutrition/domain/meal/dto/request/MealFoodRegisterRequestDto.java
@@ -11,7 +11,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MealFoodRegisterRequestDto {
-    private MealType mealTime;
+    private MealType mealType;
     private String imageUrl;
     private List<MealFoodDto> foods;
 

--- a/src/main/java/com/example/myNutrition/domain/meal/dto/request/MealFoodRegisterRequestDto.java
+++ b/src/main/java/com/example/myNutrition/domain/meal/dto/request/MealFoodRegisterRequestDto.java
@@ -46,4 +46,7 @@ public class MealFoodRegisterRequestDto {
             private Double vitaminB6;            // 비타민B6(mg)
         }
     }
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/com/example/myNutrition/domain/meal/dto/response/DailyMealRecordResponseDto.java
+++ b/src/main/java/com/example/myNutrition/domain/meal/dto/response/DailyMealRecordResponseDto.java
@@ -1,10 +1,9 @@
 package com.example.myNutrition.domain.meal.dto.response;
 
-import com.example.myNutrition.domain.meal.entity.MealTime;
+import com.example.myNutrition.domain.meal.entity.MealType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -20,7 +19,7 @@ public class DailyMealRecordResponseDto {
     @Builder
     @AllArgsConstructor
     public static class MealRecordDto {
-        private MealTime mealTime;
+        private MealType mealTime;
         private List<MealFoodDto> foods;
 
         @Getter
@@ -32,15 +31,6 @@ public class DailyMealRecordResponseDto {
             private Double amount;
             private NutritionSummaryDto nutrition;
 
-            @Getter
-            @Builder
-            @AllArgsConstructor
-            public static class NutritionSummaryDto {
-                private Double energy;
-                private Double carbohydrate;
-                private Double protein;
-                private Double fat;
-            }
         }
     }
 }

--- a/src/main/java/com/example/myNutrition/domain/meal/dto/response/DailyMealRecordResponseDto.java
+++ b/src/main/java/com/example/myNutrition/domain/meal/dto/response/DailyMealRecordResponseDto.java
@@ -27,6 +27,7 @@ public class DailyMealRecordResponseDto {
         @AllArgsConstructor
         public static class MealFoodDto {
             private String name;
+            private String fullName;
             private String imageUrl;
             private Double amount;
             private NutritionSummaryDto nutrition;

--- a/src/main/java/com/example/myNutrition/domain/meal/dto/response/DailyMealRecordResponseDto.java
+++ b/src/main/java/com/example/myNutrition/domain/meal/dto/response/DailyMealRecordResponseDto.java
@@ -19,7 +19,7 @@ public class DailyMealRecordResponseDto {
     @Builder
     @AllArgsConstructor
     public static class MealRecordDto {
-        private MealType mealTime;
+        private MealType mealType;
         private List<MealFoodDto> foods;
 
         @Getter

--- a/src/main/java/com/example/myNutrition/domain/meal/dto/response/DailyNutritionSummaryResponseDto.java
+++ b/src/main/java/com/example/myNutrition/domain/meal/dto/response/DailyNutritionSummaryResponseDto.java
@@ -9,11 +9,61 @@ import java.time.LocalDate;
 @Builder
 public class DailyNutritionSummaryResponseDto {
     private LocalDate date;
-    private Double totalEnergy;
-    private Double totalCarbohydrate;
-    private Double totalProtein;
-    private Double totalFat;
-    private Double totalCalcium;
-    private Double totalVitaminA;
-    private Double totalVitaminC;
+    private Double energy;               // 에너지(kcal)
+    private Double carbohydrate;         // 탄수화물(g)
+    private Double protein;              // 단백질(g)
+    private Double fat;                  // 지방(g)
+    private Double saturatedFattyAcid;   // 포화지방산(g)
+    private Double transFattyAcid;       // 트랜스지방산(g)
+    private Double cholesterol;          // 콜레스테롤(mg)
+    private Double totalSugars;          // 당류(g)
+    private Double totalDietaryFiber;    // 식이섬유(g)
+    private Double sodium;               // 나트륨(mg)
+    private Double calcium;              // 칼슘(mg)
+    private Double vitaminA;             // 비타민A(μg RE)
+    private Double vitaminC;             // 비타민C(mg)
+    private Double vitaminD;             // 비타민D(μg)
+    private Double vitaminE;             // 비타민E(mg α-TE)
+    private Double vitaminB6;            // 비타민B6(mg)
+
+    public static DailyNutritionSummaryResponseDto from(
+            LocalDate date,
+            double energy,
+            double carbohydrate,
+            double protein,
+            double fat,
+            double saturatedFattyAcid,
+            double transFattyAcid,
+            double cholesterol,
+            double totalSugars,
+            double totalDietaryFiber,
+            double sodium,
+            double calcium,
+            double vitaminA,
+            double vitaminC,
+            double vitaminD,
+            double vitaminE,
+            double vitaminB6
+    ) {
+        return DailyNutritionSummaryResponseDto.builder()
+                .date(date)
+                .energy(energy)
+                .carbohydrate(carbohydrate)
+                .protein(protein)
+                .fat(fat)
+                .saturatedFattyAcid(saturatedFattyAcid)
+                .transFattyAcid(transFattyAcid)
+                .cholesterol(cholesterol)
+                .totalSugars(totalSugars)
+                .totalDietaryFiber(totalDietaryFiber)
+                .sodium(sodium)
+                .calcium(calcium)
+                .vitaminA(vitaminA)
+                .vitaminC(vitaminC)
+                .vitaminD(vitaminD)
+                .vitaminE(vitaminE)
+                .vitaminB6(vitaminB6)
+                .build();
+    }
 }
+

--- a/src/main/java/com/example/myNutrition/domain/meal/dto/response/NutritionSummaryDto.java
+++ b/src/main/java/com/example/myNutrition/domain/meal/dto/response/NutritionSummaryDto.java
@@ -1,0 +1,58 @@
+package com.example.myNutrition.domain.meal.dto.response;
+
+import com.example.myNutrition.domain.meal.entity.NutritionDetail;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class NutritionSummaryDto {
+    private Double energy;               // 에너지(kcal)
+    private Double carbohydrate;         // 탄수화물(g)
+    private Double protein;              // 단백질(g)
+    private Double fat;                  // 지방(g)
+    private Double saturatedFattyAcid;   // 포화지방산(g)
+    private Double transFattyAcid;       // 트랜스지방산(g)
+    private Double cholesterol;          // 콜레스테롤(mg)
+    private Double totalSugars;          // 당류(g)
+    private Double totalDietaryFiber;    // 식이섬유(g)
+    private Double sodium;               // 나트륨(mg)
+    private Double calcium;              // 칼슘(mg)
+    private Double vitaminA;             // 비타민A(μg RE)
+    private Double vitaminC;             // 비타민C(mg)
+    private Double vitaminD;             // 비타민D(μg)
+    private Double vitaminE;             // 비타민E(mg α-TE)
+    private Double vitaminB6;            // 비타민B6(mg)
+
+
+    public static NutritionSummaryDto from(NutritionDetail detail) {
+        if (detail == null) {
+            return NutritionSummaryDto.builder().build(); // 모든 값 null 또는 0.0으로 초기화
+        }
+
+        return NutritionSummaryDto.builder()
+                .energy(nullSafe(detail.getEnergy()))
+                .carbohydrate(nullSafe(detail.getCarbohydrate()))
+                .protein(nullSafe(detail.getProtein()))
+                .fat(nullSafe(detail.getFat()))
+                .saturatedFattyAcid(nullSafe(detail.getSaturatedFat()))
+                .transFattyAcid(nullSafe(detail.getTransFat()))
+                .cholesterol(nullSafe(detail.getCholesterol()))
+                .totalSugars(nullSafe(detail.getSugar()))
+                .totalDietaryFiber(nullSafe(detail.getDietaryFiber()))
+                .sodium(nullSafe(detail.getSodium()))
+                .calcium(nullSafe(detail.getCalcium()))
+                .vitaminA(nullSafe(detail.getVitaminA()))
+                .vitaminC(nullSafe(detail.getVitaminC()))
+                .vitaminD(nullSafe(detail.getVitaminD()))
+                .vitaminE(nullSafe(detail.getVitaminE()))
+                .vitaminB6(nullSafe(detail.getVitaminB()))
+                .build();
+    }
+
+    private static Double nullSafe(Double value) {
+        return value != null ? value : 0.0;
+    }
+}

--- a/src/main/java/com/example/myNutrition/domain/meal/entity/MealFood.java
+++ b/src/main/java/com/example/myNutrition/domain/meal/entity/MealFood.java
@@ -18,6 +18,7 @@ public class MealFood {
     private Long id;
 
     private String name; // 음식 이름
+    private String fullName; // 음식 이름
     private Double amount; // g 또는 ml
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -28,8 +29,9 @@ public class MealFood {
     private NutritionDetail nutritionDetail;
 
     @Builder
-    public MealFood(String name, double amount, MealImage mealImage, NutritionDetail nutritionDetail) {
+    public MealFood(String name,String fullName, double amount, MealImage mealImage, NutritionDetail nutritionDetail) {
         this.name = name;
+        this.fullName = fullName;
         this.amount = amount;
         this.mealImage = mealImage;
         this.nutritionDetail = nutritionDetail;

--- a/src/main/java/com/example/myNutrition/domain/meal/entity/MealRecord.java
+++ b/src/main/java/com/example/myNutrition/domain/meal/entity/MealRecord.java
@@ -21,7 +21,7 @@ public class MealRecord extends BaseTimeEntity {
     private Long id;
 
     @Enumerated(EnumType.STRING)
-    private MealTime mealTime;
+    private MealType mealType;
 
     @OneToMany(mappedBy = "mealRecord", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MealImage> mealImages = new ArrayList<>();
@@ -30,8 +30,8 @@ public class MealRecord extends BaseTimeEntity {
     private User user;
 
     @Builder
-    public MealRecord(MealTime mealTime, User user) {
-        this.mealTime = mealTime;
+    public MealRecord(MealType mealType, User user) {
+        this.mealType = mealType;
         this.user = user;
     }
 

--- a/src/main/java/com/example/myNutrition/domain/meal/entity/MealType.java
+++ b/src/main/java/com/example/myNutrition/domain/meal/entity/MealType.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public enum MealTime {
+public enum MealType {
     BREAKFAST("아침"),
     LUNCH("점심"),
     DINNER("저녁"),

--- a/src/main/java/com/example/myNutrition/domain/meal/entity/NutritionDetail.java
+++ b/src/main/java/com/example/myNutrition/domain/meal/entity/NutritionDetail.java
@@ -1,5 +1,6 @@
 package com.example.myNutrition.domain.meal.entity;
 
+import com.example.myNutrition.domain.meal.dto.request.MealFoodRegisterRequestDto;
 import com.example.myNutrition.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -22,39 +23,61 @@ public class NutritionDetail {
     private Double carbohydrate;
     private Double protein;
     private Double fat;
+    private Double saturatedFat;   // 포화지방산
+    private Double transFat;       // 트랜스지방산
     private Double cholesterol;
-    private Double dietaryFiber;
-    private Double calcium;
-    private Double saturatedFat;
-    private Double sodium;
     private Double sugar;
-    private Double transFat;
+    private Double dietaryFiber;
+    private Double sodium;
+    private Double calcium;
     private Double vitaminA;
-    private Double vitaminB;
     private Double vitaminC;
     private Double vitaminD;
     private Double vitaminE;
+    private Double vitaminB;       // vitaminB6를 vitaminB로 저장할 경우
 
     @Builder
     public NutritionDetail(Double energy, Double carbohydrate, Double protein, Double fat,
-                           Double cholesterol, Double dietaryFiber, Double calcium, Double saturatedFat,
-                           Double sodium, Double sugar, Double transFat, Double vitaminA, Double vitaminB,
-                           Double vitaminC, Double vitaminD, Double vitaminE) {
+                           Double saturatedFat, Double transFat, Double cholesterol,
+                           Double sugar, Double dietaryFiber, Double sodium, Double calcium,
+                           Double vitaminA, Double vitaminC, Double vitaminD, Double vitaminE,
+                           Double vitaminB) {
         this.energy = energy;
         this.carbohydrate = carbohydrate;
         this.protein = protein;
         this.fat = fat;
-        this.cholesterol = cholesterol;
-        this.dietaryFiber = dietaryFiber;
-        this.calcium = calcium;
         this.saturatedFat = saturatedFat;
-        this.sodium = sodium;
-        this.sugar = sugar;
         this.transFat = transFat;
+        this.cholesterol = cholesterol;
+        this.sugar = sugar;
+        this.dietaryFiber = dietaryFiber;
+        this.sodium = sodium;
+        this.calcium = calcium;
         this.vitaminA = vitaminA;
-        this.vitaminB = vitaminB;
         this.vitaminC = vitaminC;
         this.vitaminD = vitaminD;
         this.vitaminE = vitaminE;
+        this.vitaminB = vitaminB;
+    }
+
+    public static NutritionDetail from(MealFoodRegisterRequestDto.MealFoodDto.NutritionDetailDto dto) {
+        return NutritionDetail.builder()
+                .energy(dto.getEnergy())
+                .carbohydrate(dto.getCarbohydrate())
+                .protein(dto.getProtein())
+                .fat(dto.getFat())
+                .saturatedFat(dto.getSaturatedFattyAcid())
+                .transFat(dto.getTransFattyAcid())
+                .cholesterol(dto.getCholesterol())
+                .sugar(dto.getTotalSugars())
+                .dietaryFiber(dto.getTotalDietaryFiber())
+                .sodium(dto.getSodium())
+                .calcium(dto.getCalcium())
+                .vitaminA(dto.getVitaminA())
+                .vitaminC(dto.getVitaminC())
+                .vitaminD(dto.getVitaminD())
+                .vitaminE(dto.getVitaminE())
+                .vitaminB(dto.getVitaminB6())
+                .build();
     }
 }

--- a/src/main/java/com/example/myNutrition/domain/meal/repository/MealRecordRepository.java
+++ b/src/main/java/com/example/myNutrition/domain/meal/repository/MealRecordRepository.java
@@ -1,7 +1,7 @@
 package com.example.myNutrition.domain.meal.repository;
 
 import com.example.myNutrition.domain.meal.entity.MealRecord;
-import com.example.myNutrition.domain.meal.entity.MealTime;
+import com.example.myNutrition.domain.meal.entity.MealType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,7 +14,7 @@ public interface MealRecordRepository extends JpaRepository<MealRecord, Long> {
     @Query("SELECT m FROM MealRecord m WHERE m.user.id = :userId AND DATE(m.createdAt) = :date")
     List<MealRecord> findAllByUserIdAndDate(@Param("userId") Long userId, @Param("date") LocalDate date);
 
-    List<MealRecord> findAllByUserIdAndMealTimeAndCreatedAtBetween(Long userId, MealTime mealTime, LocalDateTime start, LocalDateTime end);
+    List<MealRecord> findAllByUserIdAndMealTypeAndCreatedAtBetween(Long userId, MealType mealType, LocalDateTime start, LocalDateTime end);
 
     List<MealRecord> findAllByUserIdAndCreatedAtBetween(Long userId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/example/myNutrition/domain/meal/service/MealRecordService.java
+++ b/src/main/java/com/example/myNutrition/domain/meal/service/MealRecordService.java
@@ -29,7 +29,7 @@ public class MealRecordService {
     private final MealRecordRepository mealRecordRepository;
 
     @Transactional
-    public Long registerMealRecord(MealFoodRegisterRequestDto request) {
+    public Long registerMealRecord(MealFoodRegisterRequestDto request, String imageUrl) {
         Long userId = SecurityUtils.getCurrentUserId();
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
@@ -42,7 +42,7 @@ public class MealRecordService {
 
         // MealImage 생성
         MealImage image = MealImage.builder()
-                .imageUrl(request.getImageUrl())
+                .imageUrl(imageUrl)
                 .mealRecord(mealRecord)
                 .build();
 

--- a/src/main/java/com/example/myNutrition/domain/meal/service/MealRecordService.java
+++ b/src/main/java/com/example/myNutrition/domain/meal/service/MealRecordService.java
@@ -37,7 +37,7 @@ public class MealRecordService {
         // MealRecord 생성
         MealRecord mealRecord = MealRecord.builder()
                 .user(user)
-                .mealTime(request.getMealTime())
+                .mealType(request.getMealType())
                 .build();
 
         // MealImage 생성
@@ -84,7 +84,7 @@ public class MealRecordService {
                     .collect(Collectors.toList());
 
             return DailyMealRecordResponseDto.MealRecordDto.builder()
-                    .mealTime(record.getMealTime())
+                    .mealType(record.getMealType())
                     .foods(foodDtos)
                     .build();
         }).toList();
@@ -96,13 +96,13 @@ public class MealRecordService {
     }
 
     @Transactional(readOnly = true)
-    public DailyMealRecordResponseDto.MealRecordDto getMealRecordByTime(LocalDate date, MealTime mealTime) {
+    public DailyMealRecordResponseDto.MealRecordDto getMealRecordByTime(LocalDate date, MealType mealType) {
         Long userId = SecurityUtils.getCurrentUserId();
 
         LocalDateTime start = date.atStartOfDay();
         LocalDateTime end = date.atTime(LocalTime.MAX);
 
-        List<MealRecord> records = mealRecordRepository.findAllByUserIdAndMealTimeAndCreatedAtBetween(userId, mealTime, start, end);
+        List<MealRecord> records = mealRecordRepository.findAllByUserIdAndMealTypeAndCreatedAtBetween(userId, mealType, start, end);
 
         List<DailyMealRecordResponseDto.MealRecordDto.MealFoodDto> foods = records.stream()
                 .flatMap(record -> record.getMealImages().stream())
@@ -116,7 +116,7 @@ public class MealRecordService {
                 .collect(Collectors.toList());
 
         return DailyMealRecordResponseDto.MealRecordDto.builder()
-                .mealTime(mealTime)
+                .mealType(mealType)
                 .foods(foods)
                 .build();
     }

--- a/src/main/java/com/example/myNutrition/domain/meal/service/MealRecordService.java
+++ b/src/main/java/com/example/myNutrition/domain/meal/service/MealRecordService.java
@@ -4,6 +4,7 @@ import com.example.myNutrition.common.security.util.SecurityUtils;
 import com.example.myNutrition.domain.meal.dto.request.MealFoodRegisterRequestDto;
 import com.example.myNutrition.domain.meal.dto.response.DailyMealRecordResponseDto;
 import com.example.myNutrition.domain.meal.dto.response.DailyNutritionSummaryResponseDto;
+import com.example.myNutrition.domain.meal.dto.response.NutritionSummaryDto;
 import com.example.myNutrition.domain.meal.entity.*;
 import com.example.myNutrition.domain.meal.repository.MealRecordRepository;
 import com.example.myNutrition.domain.user.entity.User;
@@ -18,6 +19,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -46,7 +48,7 @@ public class MealRecordService {
 
         // MealFood + NutritionDetail 생성 후 연결
         for (MealFoodRegisterRequestDto.MealFoodDto foodDto : request.getFoods()) {
-            NutritionDetail nutrition = createNutritionDetail(foodDto.getNutrition());
+            NutritionDetail nutrition = NutritionDetail.from(foodDto.getNutrition());
 
             MealFood mealFood = MealFood.builder()
                     .name(foodDto.getName())
@@ -63,17 +65,6 @@ public class MealRecordService {
         return mealRecord.getId();
     }
 
-    private NutritionDetail createNutritionDetail(MealFoodRegisterRequestDto.MealFoodDto.NutritionDetailDto dto) {
-        return NutritionDetail.builder()
-                .energy(dto.getEnergy())
-                .carbohydrate(dto.getCarbohydrate())
-                .protein(dto.getProtein())
-                .fat(dto.getFat())
-                .vitaminA(dto.getVitaminA())
-                .vitaminC(dto.getVitaminC())
-                .calcium(dto.getCalcium())
-                .build();
-    }
 
     @Transactional(readOnly = true)
     public DailyMealRecordResponseDto getDailyMealRecords(LocalDate date) {
@@ -88,14 +79,9 @@ public class MealRecordService {
                             .name(food.getName())
                             .imageUrl(food.getMealImage().getImageUrl())
                             .amount(food.getAmount())
-                            .nutrition(DailyMealRecordResponseDto.MealRecordDto.MealFoodDto.NutritionSummaryDto.builder()
-                                    .energy(safeValue(food.getNutritionDetail(), NutritionDetail::getEnergy))
-                                    .carbohydrate(safeValue(food.getNutritionDetail(), NutritionDetail::getCarbohydrate))
-                                    .protein(safeValue(food.getNutritionDetail(), NutritionDetail::getProtein))
-                                    .fat(safeValue(food.getNutritionDetail(), NutritionDetail::getFat))
-                                    .build())
+                            .nutrition(NutritionSummaryDto.from(food.getNutritionDetail()))
                             .build())
-                    .toList();
+                    .collect(Collectors.toList());
 
             return DailyMealRecordResponseDto.MealRecordDto.builder()
                     .mealTime(record.getMealTime())
@@ -125,14 +111,9 @@ public class MealRecordService {
                         .name(food.getName())
                         .imageUrl(food.getMealImage().getImageUrl())
                         .amount(food.getAmount())
-                        .nutrition(DailyMealRecordResponseDto.MealRecordDto.MealFoodDto.NutritionSummaryDto.builder()
-                                .energy(safeValue(food.getNutritionDetail(), NutritionDetail::getEnergy))
-                                .carbohydrate(safeValue(food.getNutritionDetail(), NutritionDetail::getCarbohydrate))
-                                .protein(safeValue(food.getNutritionDetail(), NutritionDetail::getProtein))
-                                .fat(safeValue(food.getNutritionDetail(), NutritionDetail::getFat))
-                                .build())
+                        .nutrition(NutritionSummaryDto.from(food.getNutritionDetail()))
                         .build())
-                .toList();
+                .collect(Collectors.toList());
 
         return DailyMealRecordResponseDto.MealRecordDto.builder()
                 .mealTime(mealTime)
@@ -149,40 +130,68 @@ public class MealRecordService {
 
         List<MealRecord> records = mealRecordRepository.findAllByUserIdAndCreatedAtBetween(userId, start, end);
 
+        // 누적값 초기화
         double totalEnergy = 0.0;
-        double totalCarb = 0.0;
+        double totalCarbohydrate = 0.0;
         double totalProtein = 0.0;
         double totalFat = 0.0;
+        double totalSaturatedFat = 0.0;
+        double totalTransFat = 0.0;
+        double totalCholesterol = 0.0;
+        double totalSugars = 0.0;
+        double totalDietaryFiber = 0.0;
+        double totalSodium = 0.0;
         double totalCalcium = 0.0;
         double totalVitaminA = 0.0;
         double totalVitaminC = 0.0;
+        double totalVitaminD = 0.0;
+        double totalVitaminE = 0.0;
+        double totalVitaminB6 = 0.0;
 
         for (MealRecord record : records) {
             for (MealImage image : record.getMealImages()) {
                 for (MealFood food : image.getMealFoods()) {
                     NutritionDetail detail = food.getNutritionDetail();
 
-                    totalEnergy += safeValue(detail, NutritionDetail::getEnergy);
-                    totalCarb += safeValue(detail, NutritionDetail::getCarbohydrate);
-                    totalProtein += safeValue(detail, NutritionDetail::getProtein);
-                    totalFat += safeValue(detail, NutritionDetail::getFat);
-                    totalCalcium += safeValue(detail, NutritionDetail::getCalcium);
-                    totalVitaminA += safeValue(detail, NutritionDetail::getVitaminA);
-                    totalVitaminC += safeValue(detail, NutritionDetail::getVitaminC);
+                    totalEnergy           += safeValue(detail, NutritionDetail::getEnergy);
+                    totalCarbohydrate     += safeValue(detail, NutritionDetail::getCarbohydrate);
+                    totalProtein          += safeValue(detail, NutritionDetail::getProtein);
+                    totalFat              += safeValue(detail, NutritionDetail::getFat);
+                    totalSaturatedFat     += safeValue(detail, NutritionDetail::getSaturatedFat);
+                    totalTransFat         += safeValue(detail, NutritionDetail::getTransFat);
+                    totalCholesterol      += safeValue(detail, NutritionDetail::getCholesterol);
+                    totalSugars           += safeValue(detail, NutritionDetail::getSugar);
+                    totalDietaryFiber     += safeValue(detail, NutritionDetail::getDietaryFiber);
+                    totalSodium           += safeValue(detail, NutritionDetail::getSodium);
+                    totalCalcium          += safeValue(detail, NutritionDetail::getCalcium);
+                    totalVitaminA         += safeValue(detail, NutritionDetail::getVitaminA);
+                    totalVitaminC         += safeValue(detail, NutritionDetail::getVitaminC);
+                    totalVitaminD         += safeValue(detail, NutritionDetail::getVitaminD);
+                    totalVitaminE         += safeValue(detail, NutritionDetail::getVitaminE);
+                    totalVitaminB6        += safeValue(detail, NutritionDetail::getVitaminB);
                 }
             }
         }
 
-        return DailyNutritionSummaryResponseDto.builder()
-                .date(date)
-                .totalEnergy(totalEnergy)
-                .totalCarbohydrate(totalCarb)
-                .totalProtein(totalProtein)
-                .totalFat(totalFat)
-                .totalCalcium(totalCalcium)
-                .totalVitaminA(totalVitaminA)
-                .totalVitaminC(totalVitaminC)
-                .build();
+        return DailyNutritionSummaryResponseDto.from(
+                date,
+                totalEnergy,
+                totalCarbohydrate,
+                totalProtein,
+                totalFat,
+                totalSaturatedFat,
+                totalTransFat,
+                totalCholesterol,
+                totalSugars,
+                totalDietaryFiber,
+                totalSodium,
+                totalCalcium,
+                totalVitaminA,
+                totalVitaminC,
+                totalVitaminD,
+                totalVitaminE,
+                totalVitaminB6
+        );
     }
 
     /***

--- a/src/main/java/com/example/myNutrition/domain/meal/service/MealRecordService.java
+++ b/src/main/java/com/example/myNutrition/domain/meal/service/MealRecordService.java
@@ -52,6 +52,7 @@ public class MealRecordService {
 
             MealFood mealFood = MealFood.builder()
                     .name(foodDto.getName())
+                    .fullName(foodDto.getFullName())
                     .amount(foodDto.getEatAmount())
                     .mealImage(image)
                     .nutritionDetail(nutrition)
@@ -77,6 +78,7 @@ public class MealRecordService {
                     .flatMap(image -> image.getMealFoods().stream())
                     .map(food -> DailyMealRecordResponseDto.MealRecordDto.MealFoodDto.builder()
                             .name(food.getName())
+                            .fullName(food.getFullName())
                             .imageUrl(food.getMealImage().getImageUrl())
                             .amount(food.getAmount())
                             .nutrition(NutritionSummaryDto.from(food.getNutritionDetail()))
@@ -109,6 +111,7 @@ public class MealRecordService {
                 .flatMap(image -> image.getMealFoods().stream())
                 .map(food -> DailyMealRecordResponseDto.MealRecordDto.MealFoodDto.builder()
                         .name(food.getName())
+                        .fullName(food.getFullName())
                         .imageUrl(food.getMealImage().getImageUrl())
                         .amount(food.getAmount())
                         .nutrition(NutritionSummaryDto.from(food.getNutritionDetail()))

--- a/src/main/java/com/example/myNutrition/domain/survey/dto/response/SurveyResponseDto.java
+++ b/src/main/java/com/example/myNutrition/domain/survey/dto/response/SurveyResponseDto.java
@@ -36,6 +36,7 @@ public class SurveyResponseDto {
     private List<Allergy> allergies;
     private List<HealthConcern> concerns;
     private List<HealthGoal> healthGoals;
+    private double tdee;
 
     public static SurveyResponseDto from(Survey survey) {
         return new SurveyResponseDto(
@@ -62,7 +63,8 @@ public class SurveyResponseDto {
                 survey.getFamilyHistories().stream().map(SurveyFamilyHistory::getDisease).toList(),
                 survey.getAllergies().stream().map(SurveyAllergy::getAllergy).toList(),
                 survey.getConcerns().stream().map(SurveyConcern::getConcern).toList(),
-                survey.getHealthGoals().stream().map(SurveyHealthGoal::getGoal).toList()
+                survey.getHealthGoals().stream().map(SurveyHealthGoal::getGoal).toList(),
+                survey.calculateTDEE()
         );
     }
 }

--- a/src/main/java/com/example/myNutrition/domain/survey/entity/Survey.java
+++ b/src/main/java/com/example/myNutrition/domain/survey/entity/Survey.java
@@ -159,4 +159,26 @@ public class Survey {
         this.completed = true;
     }
 
+    public double calculateTDEE() {
+        double bmr;
+
+        // BMR 계산 (Mifflin-St Jeor 공식)
+        if (this.gender == Gender.MALE) {
+            bmr = 10 * weight + 6.25 * height - 5 * age + 5;
+        } else {
+            bmr = 10 * weight + 6.25 * height - 5 * age - 161;
+        }
+
+        // 활동 지수 (ExerciseFrequency에 따라 조절)
+        double activityFactor = switch (this.exerciseFrequency) {
+            case NONE -> 1.2;
+            case LIGHT_1_3 -> 1.375;
+            case MODERATE_3_5 -> 1.55;
+            case INTENSE_6_7 -> 1.725;
+            case DAILY_ACTIVE -> 1.9;
+        };
+
+        return bmr * activityFactor;
+    }
+
 }

--- a/src/main/java/com/example/myNutrition/infra/s3/S3Config.java
+++ b/src/main/java/com/example/myNutrition/infra/s3/S3Config.java
@@ -1,0 +1,32 @@
+package com.example.myNutrition.infra.s3;
+
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCredentials= new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/example/myNutrition/infra/s3/S3Service.java
+++ b/src/main/java/com/example/myNutrition/infra/s3/S3Service.java
@@ -1,0 +1,51 @@
+package com.example.myNutrition.infra.s3;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.example.myNutrition.infra.s3.exception.ImageTypeException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String uploadImage(MultipartFile multipartFile) {
+        validateImageExtension(multipartFile);
+
+        String fileName = createUniqueFileName(multipartFile.getOriginalFilename());
+        try {
+            amazonS3Client.putObject(bucket, fileName, multipartFile.getInputStream(), null);
+        } catch (IOException e) {
+            throw new RuntimeException("S3 파일 업로드 실패", e);
+        }
+
+        return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+
+    private void validateImageExtension(MultipartFile file) {
+        List<String> validExtensions = List.of("jpg", "jpeg", "png", "gif");
+        String ext = getExtension(file.getOriginalFilename());
+        if (!validExtensions.contains(ext.toLowerCase())) {
+            throw new ImageTypeException("jpg/jpeg/png/gif만 업로드 가능합니다.");
+        }
+    }
+
+    private String createUniqueFileName(String originalName) {
+        return UUID.randomUUID() + "." + getExtension(originalName);
+    }
+
+    private String getExtension(String fileName) {
+        return fileName.substring(fileName.lastIndexOf('.') + 1);
+    }
+}

--- a/src/main/java/com/example/myNutrition/infra/s3/exception/ImageTypeException.java
+++ b/src/main/java/com/example/myNutrition/infra/s3/exception/ImageTypeException.java
@@ -1,0 +1,7 @@
+package com.example.myNutrition.infra.s3.exception;
+
+public class ImageTypeException extends RuntimeException {
+    public ImageTypeException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## 주요 변경 사항

### 1. 음식 기록 기능 구현
- `MealRecord`, `MealImage`, `MealFood`, `NutritionDetail` 도메인 설계 및 구현
- 음식 기록 시 영양성분(`NutritionDetail`)까지 저장
- 하루 기준 아침/점심/저녁/간식 구분 기록

### 2. 음식 기록 조회 API
- `/meals?date=yyyy-MM-dd` : 하루 전체 식사 기록 조회
- `/meals/{mealType}` : 특정 식사 시간의 음식 기록 조회
- 하루 기준 음식별 영양소도 함께 반환 (`NutritionSummaryDto`)

### 3. 하루 총 섭취 영양소 요약 API 구현
- `/meals/nutrition/summary?date=yyyy-MM-dd`
- 사용자의 하루 섭취 영양성분 총합 반환
- 총합 계산 시 `null` 값은 `0.0` 처리 (`safeValue` 유틸 사용)
- 정적 팩토리 메서드 `DailyNutritionSummaryResponseDto.from(...)` 적용

### 4. S3 이미지 업로드 적용
- `MultipartFile` → S3 업로드 후 URL 저장
- 이미지 업로드 실패/확장자 오류/삭제 로직 등 예외 처리 포함

### 5. 영양소 Dto 및 엔티티 통일성 정비
- `NutritionDetailDto`, `NutritionSummaryDto`, `NutritionDetail` 정리
- Builder 패턴 → `from()` 정적 팩토리 메서드로 통일