### PR TITLE
feat :: 유저별 영양소 할당량 계산 및 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/myNutrition/domain/userNutritiontarget/controller/UserNutritionTargetController.java
+++ b/src/main/java/com/example/myNutrition/domain/userNutritiontarget/controller/UserNutritionTargetController.java
@@ -1,0 +1,28 @@
+package com.example.myNutrition.domain.userNutritiontarget.controller;
+
+import com.example.myNutrition.common.exception.NotFoundException;
+import com.example.myNutrition.common.response.SingleResponse;
+import com.example.myNutrition.common.security.util.SecurityUtils;
+import com.example.myNutrition.domain.userNutritiontarget.dto.UserNutritionTargetResponseDto;
+import com.example.myNutrition.domain.userNutritiontarget.entity.UserNutritionTarget;
+import com.example.myNutrition.domain.userNutritiontarget.service.UserNutritionTargetService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController("/")
+@RequiredArgsConstructor
+public class UserNutritionTargetController {
+
+    private final UserNutritionTargetService userNutritionTargetService;
+
+    @Operation(summary = "유저의 일일 영양소 목표값 조회")
+    @GetMapping
+    public ResponseEntity<SingleResponse<UserNutritionTargetResponseDto>> getUserNutritionTarget() {
+        UserNutritionTargetResponseDto response = userNutritionTargetService.getTargetForCurrentUser();
+        return ResponseEntity.ok(new SingleResponse<>(200, "사용자 영양소 할당량 조회 성공", response));
+    }
+
+}

--- a/src/main/java/com/example/myNutrition/domain/userNutritiontarget/dto/UserNutritionTargetResponseDto.java
+++ b/src/main/java/com/example/myNutrition/domain/userNutritiontarget/dto/UserNutritionTargetResponseDto.java
@@ -1,0 +1,50 @@
+// UserNutritionTargetResponseDto.java
+package com.example.myNutrition.domain.userNutritiontarget.dto;
+
+import com.example.myNutrition.domain.userNutritiontarget.entity.UserNutritionTarget;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserNutritionTargetResponseDto {
+    private Double energy;
+    private Double carbohydrate;
+    private Double protein;
+    private Double fat;
+    private Double cholesterol;
+    private Double dietaryFiber;
+    private Double saturatedFattyAcid;
+    private Double transFattyAcid;
+    private Double sugars;
+    private Double sodium;
+    private Double calcium;
+    private Double vitaminA;
+    private Double vitaminC;
+    private Double vitaminD;
+    private Double vitaminE;
+    private Double vitaminK;
+
+    public static UserNutritionTargetResponseDto from(UserNutritionTarget target) {
+        return UserNutritionTargetResponseDto.builder()
+                .energy(target.getEnergy())
+                .carbohydrate(target.getCarbohydrate())
+                .protein(target.getProtein())
+                .fat(target.getFat())
+                .cholesterol(target.getCholesterol())
+                .dietaryFiber(target.getDietaryFiber())
+                .saturatedFattyAcid(target.getSaturatedFattyAcid())
+                .transFattyAcid(target.getTransFattyAcid())
+                .sugars(target.getSugars())
+                .sodium(target.getSodium())
+                .calcium(target.getCalcium())
+                .vitaminA(target.getVitaminA())
+                .vitaminC(target.getVitaminC())
+                .vitaminD(target.getVitaminD())
+                .vitaminE(target.getVitaminE())
+                .vitaminK(target.getVitaminK())
+                .build();
+    }
+}

--- a/src/main/java/com/example/myNutrition/domain/userNutritiontarget/entity/UserNutritionTarget.java
+++ b/src/main/java/com/example/myNutrition/domain/userNutritiontarget/entity/UserNutritionTarget.java
@@ -1,0 +1,110 @@
+package com.example.myNutrition.domain.userNutritiontarget.entity;
+
+import com.example.myNutrition.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserNutritionTarget {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    private Double energy;
+    private Double carbohydrate;
+    private Double protein;
+    private Double fat;
+    private Double cholesterol;
+    private Double dietaryFiber;
+    private Double saturatedFattyAcid;
+    private Double transFattyAcid;
+    private Double sugars;
+    private Double sodium;
+    private Double calcium;
+    private Double vitaminA;
+    private Double vitaminC;
+    private Double vitaminD;
+    private Double vitaminE;
+    private Double vitaminK;
+
+    @Builder
+    private UserNutritionTarget(User user,
+                                Double energy,
+                                Double carbohydrate,
+                                Double protein,
+                                Double fat,
+                                Double cholesterol,
+                                Double dietaryFiber,
+                                Double saturatedFattyAcid,
+                                Double transFattyAcid,
+                                Double sugars,
+                                Double sodium,
+                                Double calcium,
+                                Double vitaminA,
+                                Double vitaminC,
+                                Double vitaminD,
+                                Double vitaminE,
+                                Double vitaminK) {
+        this.user = user;
+        this.energy = energy;
+        this.carbohydrate = carbohydrate;
+        this.protein = protein;
+        this.fat = fat;
+        this.cholesterol = cholesterol;
+        this.dietaryFiber = dietaryFiber;
+        this.saturatedFattyAcid = saturatedFattyAcid;
+        this.transFattyAcid = transFattyAcid;
+        this.sugars = sugars;
+        this.sodium = sodium;
+        this.calcium = calcium;
+        this.vitaminA = vitaminA;
+        this.vitaminC = vitaminC;
+        this.vitaminD = vitaminD;
+        this.vitaminE = vitaminE;
+        this.vitaminK = vitaminK;
+    }
+
+    public static UserNutritionTarget of(User user,
+                                         Double energy,
+                                         Double carbohydrate,
+                                         Double protein,
+                                         Double fat,
+                                         Double cholesterol,
+                                         Double dietaryFiber,
+                                         Double saturatedFattyAcid,
+                                         Double transFattyAcid,
+                                         Double sugars,
+                                         Double sodium,
+                                         Double calcium,
+                                         Double vitaminA,
+                                         Double vitaminC,
+                                         Double vitaminD,
+                                         Double vitaminE,
+                                         Double vitaminK) {
+        return UserNutritionTarget.builder()
+                .user(user)
+                .energy(energy)
+                .carbohydrate(carbohydrate)
+                .protein(protein)
+                .fat(fat)
+                .cholesterol(cholesterol)
+                .dietaryFiber(dietaryFiber)
+                .saturatedFattyAcid(saturatedFattyAcid)
+                .transFattyAcid(transFattyAcid)
+                .sugars(sugars)
+                .sodium(sodium)
+                .calcium(calcium)
+                .vitaminA(vitaminA)
+                .vitaminC(vitaminC)
+                .vitaminD(vitaminD)
+                .vitaminE(vitaminE)
+                .vitaminK(vitaminK)
+                .build();
+    }
+}

--- a/src/main/java/com/example/myNutrition/domain/userNutritiontarget/exception/UserNutritionTargetCreationFailedException.java
+++ b/src/main/java/com/example/myNutrition/domain/userNutritiontarget/exception/UserNutritionTargetCreationFailedException.java
@@ -1,0 +1,7 @@
+package com.example.myNutrition.domain.userNutritiontarget.exception;
+
+public class UserNutritionTargetCreationFailedException extends RuntimeException {
+    public UserNutritionTargetCreationFailedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/myNutrition/domain/userNutritiontarget/repository/UserNutritionTargetRepository.java
+++ b/src/main/java/com/example/myNutrition/domain/userNutritiontarget/repository/UserNutritionTargetRepository.java
@@ -1,0 +1,11 @@
+package com.example.myNutrition.domain.userNutritiontarget.repository;
+
+import com.example.myNutrition.domain.meal.entity.MealRecord;
+import com.example.myNutrition.domain.userNutritiontarget.entity.UserNutritionTarget;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserNutritionTargetRepository extends JpaRepository<UserNutritionTarget, Long> {
+    Optional<UserNutritionTarget> findByUserId(Long userId);;
+}

--- a/src/main/java/com/example/myNutrition/domain/userNutritiontarget/service/UserNutritionTargetService.java
+++ b/src/main/java/com/example/myNutrition/domain/userNutritiontarget/service/UserNutritionTargetService.java
@@ -1,0 +1,108 @@
+package com.example.myNutrition.domain.userNutritiontarget.service;
+
+import com.example.myNutrition.common.exception.NotFoundException;
+import com.example.myNutrition.common.security.util.SecurityUtils;
+import com.example.myNutrition.domain.survey.entity.Survey;
+import com.example.myNutrition.domain.survey.enums.singular.Gender;
+import com.example.myNutrition.domain.survey.repository.SurveyRepository;
+import com.example.myNutrition.domain.user.entity.User;
+import com.example.myNutrition.domain.user.exception.UserNotFoundException;
+import com.example.myNutrition.domain.user.repository.UserRepository;
+import com.example.myNutrition.domain.userNutritiontarget.dto.UserNutritionTargetResponseDto;
+import com.example.myNutrition.domain.userNutritiontarget.entity.UserNutritionTarget;
+import com.example.myNutrition.domain.userNutritiontarget.exception.UserNutritionTargetCreationFailedException;
+import com.example.myNutrition.domain.userNutritiontarget.repository.UserNutritionTargetRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserNutritionTargetService {
+
+    private final UserNutritionTargetRepository userNutritionTargetRepository;
+    private final UserRepository userRepository;
+    private final SurveyRepository surveyRepository;
+
+    @Transactional
+    public void calculateAndSave(User user, Survey survey) {
+        // 1. 총 에너지 소비량(TDEE) 계산
+        double energy = survey.calculateTDEE();
+
+        // 2. 영양소 비율에 따른 kcal 계산
+        double proteinKcal = energy * 0.2;
+        double fatKcal = energy * 0.25;
+        double carbKcal = energy - proteinKcal - fatKcal;
+
+        // 3. g 단위로 변환
+        double protein = proteinKcal / 4; // 단백질 1g = 4kcal
+        double fat = fatKcal / 9;         // 지방 1g = 9kcal
+        double carbohydrate = carbKcal / 4; // 탄수화물 1g = 4kcal
+
+        // 4. 고정값 또는 성별 기반 기타 영양소 설정
+        double cholesterol = 300.0; // mg
+        double dietaryFiber = (survey.getGender() == Gender.MALE) ? 25.0 : 20.0; // g
+        double saturatedFattyAcid = fat * 0.3; // g, 지방 중 약 30% 가정
+        double transFattyAcid = 1.0; // g, 권장상한
+        double sugars = 50.0; // g
+        double sodium = 1500.0; // mg
+        double calcium = 700.0; // mg
+        double vitaminA = 700.0; // μg RE
+        double vitaminC = 100.0; // mg
+        double vitaminD = 10.0; // μg
+        double vitaminE = 15.0; // mg α-TE
+        double vitaminK = 90.0; // μg
+
+        // 5. UserNutritionTarget 엔티티 생성 및 저장
+        UserNutritionTarget target = UserNutritionTarget.of(
+                user,
+                energy,
+                carbohydrate,
+                protein,
+                fat,
+                cholesterol,
+                dietaryFiber,
+                saturatedFattyAcid,
+                transFattyAcid,
+                sugars,
+                sodium,
+                calcium,
+                vitaminA,
+                vitaminC,
+                vitaminD,
+                vitaminE,
+                vitaminK
+        );
+
+        userNutritionTargetRepository.save(target);
+    }
+
+
+    @Transactional
+    public UserNutritionTargetResponseDto getTargetForCurrentUser() {
+        Long userId = SecurityUtils.getCurrentUserId();
+
+        // 1. 조회 시도
+        Optional<UserNutritionTarget> optional = userNutritionTargetRepository.findByUserId(userId);
+
+        if (optional.isPresent()) {
+            return UserNutritionTargetResponseDto.from(optional.get());
+        }
+
+        // 2. 없으면 계산 및 저장
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+        Survey survey = surveyRepository.findByUserId(userId)
+                .orElseThrow(() -> new NotFoundException("설문 정보가 없습니다."));
+
+        // 3. 계산 및 저장
+        calculateAndSave(user, survey);
+
+        UserNutritionTarget target = userNutritionTargetRepository.findByUserId(userId)
+                .orElseThrow(() -> new UserNutritionTargetCreationFailedException("영양소 목표 계산 후 조회 실패"));
+
+        return UserNutritionTargetResponseDto.from(target);
+    }
+}

--- a/src/main/java/com/example/myNutrition/domain/userNutritiontarget/util/NutritionUtils.java
+++ b/src/main/java/com/example/myNutrition/domain/userNutritiontarget/util/NutritionUtils.java
@@ -1,0 +1,17 @@
+package com.example.myNutrition.domain.userNutritiontarget.util;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public class NutritionUtils {
+
+    /**
+     * 주어진 값을 소수점 1자리까지 반올림합니다.
+     * 예: 3.14159 → 3.1
+     */
+    public static double round1(double value) {
+        return BigDecimal.valueOf(value)
+                .setScale(1, RoundingMode.HALF_UP)
+                .doubleValue();
+    }
+}


### PR DESCRIPTION
## Summary
- 설문조사 정보를 기반으로 사용자의 TDEE를 계산하고,
  이를 바탕으로 주요 영양소 할당량을 산출하여 DB에 저장
- 사용자별 하루 에너지 및 영양소 목표치를 조회할 수 있는 API 추가


## 주요 변경사항
- `UserNutritionTargetService` 생성
  - `calculateAndSave(User, Survey)` 메서드로 정적 계산 로직 분리
  - `getTargetForCurrentUser()` 메서드에서 값 조회 + 없으면 생성
- TDEE 계산 로직은 `Survey.calculateTDEE()`에서 수행
- `/api/nutrition/target` GET API 구현
- 소수점 1자리 반올림을 위한 `NutritionUtils.round1()` 유틸 추가

## 영양소 계산 기준
- 에너지(TDEE): 성별 + 키 + 몸무게 + 나이 + 운동 빈도 기반 계산
- 탄단지 비율: 탄수화물 55%, 단백질 20%, 지방 25%
- 기타 영양소: 고정값 또는 성별 기반 설정